### PR TITLE
changed the branches field main -> master

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -4,7 +4,7 @@ name: Fly Deploy
 on:
   push:
     branches:
-      - main
+      - master
 jobs:
   deploy:
     name: Deploy app


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Attempted resolution to GitHub actions for fly deployment of Quill
# Description
<!--- Describe your changes in detail -->
Changed the branches field from main to master so that the **master** branch gets found. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since there is NO branch named "main", the GitHub Actions specified in **fly-deploy.yml** don't get executed when there are new code changes merged. To hopefully ensure that the deployed Quill app is updated according to code merges, this change to  **fly-deploy.yml** is necessary to ensure that code changes are automatically detected when new code gets merged. 

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
Checked the GitHub actions logs for fly-deploy.yml to ensure that all steps pass. 
<!--- Include details of your testing environment, and the tests you ran to -->
Tested on my forked quill repository whenever I pushed changes to fly-deploy.yml and generated a FLY_API_TOKEN from fly.io to use as a secret to the forked quill repository. 

## Screenshots (if appropriate)
![Screenshot 2024-08-04 at 5 39 19 PM](https://github.com/user-attachments/assets/a9699ce3-5a53-415f-87b8-b5844263fc74)
