### PR TITLE
Restrict team joining until application submission and acceptance.

### DIFF
--- a/app/server/controllers/UserController.js
+++ b/app/server/controllers/UserController.js
@@ -481,6 +481,11 @@ UserController.createOrJoinTeam = function(id, code, isCreate, callback) {
   User.find({})
     .exec(function(err, users) {
       if (err) return callback(err);
+      const userWithProfile = users.find(user => user.id.toString() === id && user.status && user.status.admitted === true);
+
+      if (!userWithProfile) {
+        return callback({ message: "You can only join or create a team once your profile is completed and you have been accepted." });
+      }
 
       // Normalize all stored team codes for comparison
       const existingTeam = users.find(user => user.teamCode && user.teamCode.toLowerCase() === normalizedCode);
@@ -508,7 +513,7 @@ UserController.createOrJoinTeam = function(id, code, isCreate, callback) {
         const teamMembers = users.filter(user => user.teamCode && user.teamCode.toLowerCase() === normalizedCode);
         
         if (existingTeam && teamMembers.length >= maxTeamSize) {
-          return callback({ message: "Team is full." });
+          return callback({ message: `Team is full. The maximum number of team members allowed is ${maxTeamSize}.` });
         }
 
         User.findOneAndUpdate(


### PR DESCRIPTION
Restrict team joining until application submission and acceptance. Display the maximum number of team members in the error message.

## Description
Implemented additional validations for creating or joining the team. Now, the error message displayed when attempting to join a full team includes the maximum number of team members allowed. Also, previously, a user could join a team without completing their profile, leading to the placeholder text "Somebody (has not filled out their profile!)". With these changes, users can only create or join a team if they have completed their profile and have been accepted by the admin.

## Motivation and Context
These changes ensure that only users with completed profiles, who have been accepted by admins, can create or join teams. It also enhances the error messaging for more clarity when a team is full displaying the maximum number of members allowed.

## How Has This Been Tested
Tested in a development environment by attempting to join teams with incomplete profiles, full teams, and verified user accounts. Verified that the new error messages and restrictions are functioning as intended.

## Screenshots (if appropriate)
<img width="1118" alt="Screenshot 2024-08-20 at 5 49 14 PM" src="https://github.com/user-attachments/assets/745abcac-ae97-4729-9137-8a3ee2a8faba">
<img width="1125" alt="Screenshot 2024-08-20 at 9 25 25 PM" src="https://github.com/user-attachments/assets/d59a1f5d-20ca-4c9c-9205-27815a9be7f1">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
